### PR TITLE
Add ApiGen support

### DIFF
--- a/assets/stylesheets/apigen.css
+++ b/assets/stylesheets/apigen.css
@@ -1,0 +1,557 @@
+/*!
+ * ApiGen 2.8.0 - API documentation generator for PHP 5.3+
+ *
+ * Copyright (c) 2010-2011 David Grudl (http://davidgrudl.com)
+ * Copyright (c) 2011-2012 Jaroslav Hanslík (https://github.com/kukulich)
+ * Copyright (c) 2011-2012 Ondřej Nešpor (https://github.com/Andrewsville)
+ *
+ * For the full copyright and license information, please view
+ * the file LICENSE.md that was distributed with this source code.
+ */
+
+#content {
+	font: 13px/1.5 Verdana, 'Geneva CE', lucida, sans-serif;
+	margin: 0;
+	padding: 0;
+	background: #ffffff;
+	color: #333333;
+}
+
+#content h1, #content h2, #content h3, #content h4, #content caption {
+	font-family: 'Trebuchet MS', 'Geneva CE', lucida, sans-serif;
+	color: #053368;
+}
+
+#content h1 {
+	color: #1e5eb6;
+	font-size: 230%;
+	font-weight: normal;
+	margin: .3em 0;
+}
+
+#content h2 {
+	color: #1e5eb6;
+	font-size: 150%;
+	font-weight: normal;
+	margin: -.3em 0 .3em 0;
+}
+
+#content h3 {
+	font-size: 1.6em;
+	font-weight: normal;
+	margin-bottom: 2px;
+}
+
+#content h4 {
+	font-size: 100%;
+	font-weight: bold;
+	padding: 0;
+	margin: 0;
+}
+
+#content caption {
+	border: 1px solid #cccccc;
+	background: #ecede5;
+	font-weight: bold;
+	font-size: 1.2em;
+	padding: 3px 5px;
+	text-align: left;
+	margin-bottom: 0;
+}
+
+#content p {
+	margin: .7em 0 1em;
+	padding: 0;
+}
+
+#content hr {
+	margin: 2em 0 1em;
+	border: none;
+	border-top: 1px solid #cccccc;
+	height: 0;
+}
+
+#content a {
+	color: #006aeb;
+	padding: 3px 1px;
+	text-decoration: none;
+}
+
+#content h1 a {
+	color: #1e5eb6;
+}
+
+#content a:hover, #content a:active, #content a:focus, #content a:hover b, #content a:hover var {
+	background-color: #006aeb;
+	color: #ffffff !important;
+}
+
+#content code, #content var, #content pre {
+	font-family: monospace;
+}
+
+#content var {
+	font-weight: bold;
+	font-style: normal;
+	color: #ca8a04;
+}
+
+#content pre {
+	margin: 0;
+}
+
+#content code a b {
+	color: #000000;
+}
+
+#content .deprecated {
+	text-decoration: line-through;
+}
+
+#content .invalid {
+	color: #e71818;
+}
+
+#content .hidden {
+	display: none;
+}
+
+/* Left side */
+#content #left {
+	overflow: auto;
+	width: 270px;
+	height: 100%;
+	position: fixed;
+}
+
+/* Menu */
+#content #menu {
+	padding: 10px;
+}
+
+#content #menu ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+#content #menu ul ul {
+	padding-left: 10px;
+}
+
+#content #menu li {
+	white-space: nowrap;
+	position: relative;
+}
+
+#content #menu a {
+	display: block;
+	padding: 0 2px;
+}
+
+#content #menu .active > a, #content #menu > span {
+	color: #333333;
+	background: none;
+	font-weight: bold;
+}
+
+#content #menu .active > a.invalid {
+	color: #e71818;
+}
+
+#content #menu .active > a:hover, #content #menu .active > a:active, #content #menu .active > a:focus {
+	background-color: #006aeb;
+}
+
+#content #menu #groups span {
+	position: absolute;
+	top: 4px;
+	right: 2px;
+	cursor: pointer;
+	display: block;
+	width: 12px;
+	height: 12px;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJBJREFUeNpi/P//P0PD1m//GYgADd5cjFAmUeqBgJGxfsvX/0CNRKkGOgRkCQNj9hui1P+fKsLAxEBjMPQtYEEPYxyRizOMscYsUhzR2QdEpiZsLh2+kUxzCxhpXVTQ3gfDsywCuxRHrsblUly5emDLIhif2LIIxh/4soiQy9HLImwuHxgf0KJUHfplEUCAAQD6zlAlEu1wEQAAAABJRU5ErkJggg==') transparent 0 0 no-repeat;
+}
+
+#content #menu #groups span:hover {
+	background-position: -12px 0;
+}
+
+#content #menu #groups span.collapsed {
+	background-position: 0 -12px;
+}
+
+#content #menu #groups span.collapsed:hover {
+	background-position: -12px -12px;
+}
+
+#content #menu #groups ul.collapsed {
+	display: none;
+}
+
+/* Right side */
+#content #right {
+	overflow: auto;
+	margin-left: 275px;
+	height: 100%;
+	position: fixed;
+	left: 0;
+	right: 0;
+}
+
+#content #rightInner {
+	max-width: 1000px;
+	min-width: 350px;
+}
+
+/* Search */
+#content #search {
+	display: none;
+}
+
+/* Navigation */
+#content #navigation {
+	padding: 3px 8px;
+	background-color: #f6f6f4;
+	height: 26px;
+}
+
+#content #navigation ul {
+	list-style: none;
+	margin: 0 8px 4px 0;
+	padding: 0;
+	overflow: hidden;
+	float: left;
+}
+
+#content #navigation ul + ul {
+	border-left: 1px solid #000000;
+	padding-left: 8px;
+}
+
+#content #navigation ul li {
+	float: left;
+	margin: 2px;
+	padding: 0 3px;
+	font-family: Verdana, 'Geneva CE', lucida, sans-serif;
+	color: #808080;
+}
+
+#content #navigation ul li.active {
+	background-color: #053368;
+	color: #ffffff;
+	font-weight: bold;
+}
+
+#content #navigation ul li a {
+	color: #000000;
+	font-weight: bold;
+	padding: 0;
+}
+
+#content #navigation ul li span {
+	float: left;
+	padding: 0 3px;
+}
+
+#content #navigation ul li a:hover span, #content #navigation ul li a:active span, #content #navigation ul li a:focus span {
+	background-color: #006aeb;
+}
+
+/* Content */
+#content #content {
+	clear: both;
+	padding: 5px 15px;
+}
+
+#content .description pre {
+	padding: .6em;
+	background: #fcfcf7;
+}
+
+#content #content > .description {
+	background: #ecede5;
+	padding: 1px 8px;
+	margin: 1.2em 0;
+}
+
+#content #content > .description pre {
+	margin: .5em 0;
+}
+
+#content dl.tree {
+	margin: 1.2em 0;
+}
+
+#content dl.tree dd {
+	margin: 0;
+	padding: 0;
+}
+
+#content .info {
+	margin: 1.2em 0;
+}
+
+#content .summary {
+	border: 1px solid #cccccc;
+	border-collapse: collapse;
+	font-size: 1em;
+	width: 100%;
+	margin: 1.2em 0 2.4em;
+}
+
+#content .summary caption {
+	border-width: 1px 1px 0;
+}
+
+#content .summary caption.switchable {
+	background: #ecede5 url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAJCAMAAADq3ZdEAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRFIy0wAAAA7SXdQwAAAAJ0Uk5T/wDltzBKAAAALUlEQVR42mJghAMGbEwGBgZMUQYGJGEGZEG4MJJhjJjm4lCL1VwcbkBhAgQYAD19AJ7XGduaAAAAAElFTkSuQmCC') no-repeat center right;
+	cursor: pointer;
+}
+
+#content .summary td {
+	border: 1px solid #cccccc;
+	margin: 0;
+	padding: 3px 10px;
+	font-size: 1em;
+	vertical-align: top;
+}
+
+#content .summary td:first-child {
+	text-align: right;
+}
+
+#content #packages.summary td:first-child, #content #namespaces.summary td:first-child, #content .inherited.summary td:first-child, #content .used.summary td:first-child {
+	text-align: left;
+}
+
+#content .summary tr:hover td {
+	background: #f6f6f4;
+}
+
+#content .summary .description pre {
+	border: .5em solid #ecede5;
+}
+
+#content .summary .description p {
+	margin: 0;
+}
+
+#content .summary .description p + p, #content .summary .description ul {
+	margin: 3px 0 0 0;
+}
+
+#content .summary .description.detailed h4 {
+	margin-top: 3px;
+}
+
+#content .summary dl {
+	margin: 0;
+}
+
+#content .summary dd {
+	margin: 0 0 0 25px;
+}
+
+#content .name, #content .attributes {
+	white-space: nowrap;
+}
+
+#content .value {
+	white-space: pre-wrap;
+}
+
+#content td.attributes {
+	width: 1%;
+}
+
+#content .class .methods .name, #content .class .properties .name, #content .class .constants .name {
+	width: auto;
+	white-space: normal;
+}
+
+#content .class .methods .name > div > code {
+	white-space: pre-wrap;
+}
+
+#content .class .methods .name > div > code span, #content .function .value > code {
+	white-space: nowrap;
+}
+
+#content .class .methods td.name > div, #content .class td.value > div {
+	position: relative;
+	padding-right: 1em;
+}
+
+#content .anchor {
+	position: absolute;
+	top: 0;
+	right: 0;
+	line-height: 1;
+	font-size: 85%;
+	margin: 0;
+	color: #006aeb !important;
+}
+
+#content .list {
+	margin: 0 0 5px 25px;
+}
+
+#content div.invalid {
+	background-color: #fae4e0;
+	padding: 10px;
+}
+
+/* Splitter */
+#content #splitter {
+	position: fixed;
+	height: 100%;
+	width: 5px;
+	left: 270px;
+	background: #1e5eb6 url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAJAgMAAACHww4NAAAAA3NCSVQICAjb4U/gAAAACVBMVEX///////////+OSuX+AAAAA3RSTlMAM/8jH05jAAAACXBIWXMAAArwAAAK8AFCrDSYAAAAHHRFWHRTb2Z0d2FyZQBBZG9iZSBGaXJld29ya3MgQ1M0BrLToAAAABZ0RVh0Q3JlYXRpb24gVGltZQAwMy8wNy8xMdz+xJMAAAANSURBVAiZY1BzYMCBADAPA5cnpb6OAAAAAElFTkSuQmCC') left center no-repeat;
+	cursor: e-resize;
+}
+
+#content #splitter.active {
+	opacity: .5;
+}
+
+/* Footer */
+#content #footer {
+	border-top: 1px solid #e9eeef;
+	clear: both;
+	color: #a7a7a7;
+	font-size: 8pt;
+	text-align: center;
+	padding: 20px 0 0;
+	margin: 3em 0 0;
+	height: 90px;
+	background: #ffffff url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA8kAAACOCAMAAAA1p7riAAADAFBMVEXm5+Hp6uTs7ejv7+vw8e3y8u/z9PH09fL29vT29/T29/X39/X39/b39/X19vP19fP19fP29vX4+Pb3+Pb4+Pb4+Pb4+Pf4+ff4+ff5+ff5+ff5+fj5+vj5+vj5+fj5+fj5+fj7+/r7+/r7+/n6+vj6+vn6+vn6+/n6+vj6+/n6+/r6+/r7/Pv8/Pv8/Pv8/Pz7/Pv8/Pv7/Pv8/Pz8/fz8/Pz9/f39/fz9/fz8/fz9/fz9/fz+/v39/f39/f39/f39/v39/v3+/v3+/v3+/v3+/v3+/v7+/v7+/v7///7///////9MTExNTU1OTk5PT09QUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///9tt3MkAAABAHRSTlP///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8AU/cHJQAAAAlwSFlzAAALEwAACxMBAJqcGAAAGqZJREFUeAHs1s1vEkEYBnBc6q5UAwcMIdpLEwyJF+oREw8kpAn9//8fOu8z78czA7PqwdgDLzKLu3R2Pp5ft5Pz+QV1ei7reDweDodfqJ9eu93uh9ej13a7/eb11Wu9Xq9Wq8+o5XL5EXU/m80+oObz+SLXkKunel/WXVXTq9WN1rs/qcmbr1thn7xp1lgWNC+XEUrRopil4JU5TMH0iA69hHYxSIJTlOWfpDrFW2KOdwq9ZB/vLyi4eNhsNqCSGxDKDVzlJlEDudwIw+Qxqcw8o8XhfM6ST3jzRRzlx9BDbrRLuYPe60lvnw86rDTIh00esIxcNWMuMrE8Q5kupo35Yy3SkuSV6Z30IAuHBXTRME2wp0BdyO60wY61VMsL2z3uOg43QP/Z7ThbbGg3phdp0GTUfAF4SoJhmBWLYDRM2BgvcpS11YQj7Jp7QFAT4sOofHdAdjRZUGbi1B88hk769KKSwfj0zFfos3Xj3eab+C1jEHgy6xAxXht70iyczfMnmys82/zV9OCiF/zbT1eTntKuWl0r6QK1mVbVtes273HgZbgmFXn+QvHt8merrq503ThBZxqnGucaJ5tn26fb59sXRq60L43D/W1NCe8FX8aLDxVei5xHcAjDvQr28N7PPNSZsBsGYpcQQEQL2XkKxI8qLMS5wcqo/0clAzIk89cYc/REvdOdeUQYIQ04JgHQplnnG/OPRVHTirqXV4HaWQdsR+2sL2HfEW3C3eRdGacE8adb/cPq/qamFdyOdt7DEPGIxFCKPFnkl/FCr+WTEhsxdsE57ZR+NsFggJgs7fd7Vkb2rgBlybDMmvmrrJm7TDezXxzFIMoRVp59SjpJR02c7THta+TLFwva17Bp/eN5TTtF2xdbeiGcM0DJ6N5M3Yp2ia3yVhJaZstwma7/0Wx4kSnKWuSP4ZJceyQF4XgMR+KJQmmk5COuKsaE7oJndiuGXbJCBuVXyuwoyW0cBsLwQyrJS06Sm+T+F8oMLRHNRv8Ula1aiwAt2wI+kfa06Z/9+XrO9eXs7ZhnBS2fT00LalE9WYvrurB6uYV11Wb+m1UT5FLk61GVR+c/Evl1ZMk2GQIaoRDEIAhRCmOcE5zhFOf2ycD1rlkoppi18hfbm+ytV3pJ8Rpf8TsBj23m7GNp7wBYBV8rsboxVCYuwNxInpTtKaV5ObmDDqTHb2F/bbs9v0Uvn/pzTQT1H3M9YZdspW24jfcsYvetwrULtEPmkcgP+GXgIxnCWAMY0RDHMAjR8zgn9pl9apvrUpcqeTFli5aWXG0Sd2tyla7YleVX1l8TLITdsCmp7a1zutVFkf/uZfmWPP6J5WtCfvL3D+FBs3FOnn2RVteNdN3i1PWALbKFttvW2njlZkVNutT8Z9Re3utIgusEHYRRDWGsAYxoiGMYhCiFMc4JzlAqzNOKGFP5f1tnv4+09u42y1W6S/Nd64zQdbuOV/XONdgMj+10AzyYTcZA8TI7/CbJQhlOMF4meXbQWbSS7qbHH7Caa4WtF9dgf/2AWLhN9/yZotWyV3shbsZ9NDsLRjr0MQQ0QiGIQRCiFMY4JzizTXHOL7M4FahSO7TqWrVHTK51l/ZdgKu/YH1+5+3tPf0a4CnYCAdW5PCizJKFMp+j7hfppa+3WZuGTNo/dFNdm/BGW6+xX3/3PYBL9VplS3log9Qsv3/Jf/fDfKwDOdJDOdaBjmCoYw1QBEIQgyBEKYxxTkCm/mw7H1KBej2Xard2kG2y7pOXnkpy73aUPoVOFsAu+LYREF9LpNjaAJxiS3JZNsx4DvtFO1GO67Nrhotw3d6667FeN9XGOsAeu/JWzh4JxBW5HsaGwiBEKYxxTnBmm9rm9sl99jG9z+ultkGq0bhVp3qOygtck6t9A3jXhdcMhy20EG6GE96sZ6tvLrTzO7JJTpT5bHrjiO+mVmZZmwNn9BwkD8rBsmEmzqHSnx5Yb+GxV6ydDhQ8zzic8jjnfNLzrPNp5/POJ57PzEXKNQ69UF9661tvYKyrsBLGni3IIDlQBj0P/vRb8uOavD+TWsa3I4hJMVwSuxnWNQ2SgXKvH1TaJEOXBMzHffd27vnk97NfT385//0T3j/DK0aFtfVYF+TQMVmzd+LXH2KwaTPgRUHkXDvrRdWjwcM1+fk88/VZ8vIhADNrDusySQ6FAcxQ9NYdKNpJt0CYEkIQgyBEKYxxTnBmm9rm9sl9Fq9/rxQXNfdA7BaGbOsxQwbJpgAwu+JnfrC7BsoPJxPNmbN9CtTMnKNnAj33TVDCz1enTeVDm/yn5Q6PG7thII7XcCWkg9SR/gvKjM+WID78dxck/ekkEuQkfvgZIKUxp5TLRT/vA3yEDYljXFAclYflceIxrHfQpRY3xRgYo+MVMqUqpvb7oEmIG8Ve3n+x5HBDEAy3XvD/ipBBMlMulhEzO+4hcwrleTiJzEOHsXnwPHocPo1vn418mJgBqJk5V89030U1uVAmyx1mjy/vriPJRBksI2bUzJzZMz9E/ez7dJGY5ym5s2K+ZHPNfNHuqv1l5hnWmtwUZXBMkEEyUAbLJJiPpok+kEyW9XbkmCCzZKaMljVmqVmnAoDWou2snvbzPkBH5CE+xgflUXnYn++PG+zz42dfL6yZ7uOi6+fTUUpSgXgpySS6r8oSXyOZFWvG5ZiMpLuzMnN+fVn79aNjwwJxbbIZtBcdp1gemEcOQ/PYcXAePQ+fx3vHEnKVzJShDjNklqz4VkHZ8bhYjT+FyizX/5SVMzlmyEVypcyWGXPVrDl7z+Nk21oxX7K5Zr5of9XmMmqLPGPtuEJmyUwZmmpmvJZkRp1JLlbzc3JoufPLzbVWrBtsFi1Ja8ceMqfVdp7uL9xfebh0d+3x4gRvORvD4RhPx8yZPTNoFq0VQ3N93l1PIINkpKwta8xK8+fvW350GraWfZiTx8vP159vcL7DhS0eHz3JSrykButlvtqvBqwEfza1aV3+Ejv7FCrX3HBeWguvWDPWjtenxZSfv8G1XizJd3Ly1iaXdrm1zaV9fEW2jFUmONTlkEfZ6S07zFSQjen8nJxDZskrZW9ZY9aan5yX07KrxhI0ir6ZuFd3urnV1b1ubuYYK8d/v81fvg78vLX++oKmRuwUa8bg+PbnybFlxtxfemnR9eqr+eHWH705I6+UtWWPWWjWc3pSz+ppP+8DdEQeYmPyoLQaa8ca8o/kmk+yuabuWmP2muO2ukjNu+vUMhLmwzJLBspPy/WH7zmvnj1oLTrNxjQsj8sD88g8NI+dB4d2m8OR5fzs1XxbXftqXZO9Yw85l6zvrj1lbZkxS82e81dv00teKWvLDWbWHHP++arC69/3i/Kqvqyv65v6bnkL78sAjMBQHeNBHuVhHocJPZPK7h8l8DV+uSJzSdaWc8y5Zr7x0pStZYbMklPKL8sN5kaz5tx59qDjjMoD88hhaB47Ds6j5+HzeOJr2unMMmNWmi1n/m5mrLhIndfkSDJTXm+9UsClu/7odMydV6A51DtNra0V8yWba+aL9lfNl52taz4+Np5fB+S1FmjG0rGHzJJjysXyKrlaVpolZy15pZxbLpipKj8eRUZZWz7NrKOV20tP124vPl19vvzZa0Fv7Quypiwsd1e7UVfNt9fCdtG7StaONWQtWXfYoWqQDJS95QzzeYqdb3C+w6Utzvc430R21r4UR5a/D3TinssnbkYYDfsCrSV7ysqyxNwW5szw6ycLmFFzxNl7vpiB97a5ts+9ja7t9P0XIbo7aibsDUeIPw9yGnPYUoeoh/01S/aIheLlO2dO9QSx/aqIOze3bVbTjWWo7+fszb3ubnZ5t3vbwdm4f9KhYN1V67Y6FK2PybljLTkuysvfyaX+wGPONa8HZizNr3uMsCD3nkPQ93Pz/ob3d7y/ZSnCfRXGMtw+PuaceH73f74cZ3rzipxT1pI1ZWUZMbvzcS55pcyWK+ZMc58POehfy+37m/4ew9/Z1n/jwzfVueG1sdaUc8u6FrMebXveXccNtq/C61l57Pn9C1NZjgknaRCLrqXl/aK8qi/r6/pmfVffwvsyACMwVMZ4kEd5mMd5AqoxlmP6/UsVufyCl6lTMsxLzilry9Ny/KWVJeeUlWWLub2qH3rWz6I+tBw1ZcZEMuQjjNIwj/MEz/CUntOTepan43mFGBWz45oTkrL4I7j//jMXnPfWY81zyVPK3jJinmpWnOuzG4me0fUpmUT4kDDGB8VReZiPywO947CVyntqf9Wl77py1boy55i15Jyyt/w/cXeQW7mxQ2F4XxkbGWT/++mkjQwuZJE8/+EhOm/mIvlgFz+xJF27Z8y1Zs659UwI15d6qJuH43iewDN4Cs/xk+r5yxD3invG1PEMeS9Zd9xDFiXXlD/OMPMLKAmyLrmm7Habn2bn+Yl+pp/q586aZc4vj7r6O2ROuDcMEfOZrD+8rp+/9c+v+Qx+eYo9W9Yxi0e3Xf8ts7fp+/x9gX2FQbHO+M1xD5lLninf3yfzsazP5Xowf05mcTT3njHofj7v+zBUI1MkVCVT5u0jH+L1lQmuj9bq2bruX/1JFyb8v1X+aU19MD8/6KVy9gbzczLPlKlltX2CLZwrFKyULBWs1W7n6+d3uyaRJ7E+ivVZPEv+QZnfJ/tDWWTcXNeek7kfzTpoKrqez/HujFdLl4vWKwawegktMZeOa8i6ZJ2ybplj1k/XfCL3N8v93TKfys+xrDPmjmvIecn5inclD2r2P+v+5hierV/vj2fMXLPOef8bFOrf8po5vx2x1eFsef78UI5OmVrWp8TUivP6HDBFiCFjjB40R+lh6KdN9db3xvrNMZesU54tfziuJdeOdchvknXKluUnZlUz5ww6TO5aPVCPZKF6LA7Wo6lgbrhHrCvmjHXHKuRJso550AzwtvfJP26U5ztlnXJ5k+UhR11Io2k4jucJPMNJ6Y/TWHNxpFbP1NywjlhXPEvWFfeMX8cyoG1O5rdNQqw5X685zSQzy02z8+zEXm1z5a0fcJWb3w2Gn29BOWJdMWcszGR7LrcPu7Bii/HziK0Lrhtkaq1F025SN7mr5GX2Pr3bq5pzf6jWT9VcM+Yses7P5K9qKjO9/Qn7eX3UD9kq5lbz7HkOmCPEkDFGD5qj9DA9Tg/s98Q4V7+e2fSjNYcsS87fJ1uUa8sQc6v5jfPsGYPuu0dvQxiqx+JgPZqH83icMIGuR7E8i3XJnDK3LGK+kVxTppYbzJXmmTP3PHaP0ZBeCs+xk3iWn+bnPX5ZtXU8Q5aP1dywjjh/uvYp15Y5Zvs+WVY9/wm/WbLfiZtMP3WZ6yevs61ztM5Yn8ics+6Zgz6UXFPmll3Mxee+yDR+XvMF1GLIHCMHzVF6mB6nB+qRWmixNWRr2wfV6mB2Kb++zTEeWH8YnST7lHvLHLOvueKMPP/sGtRzOBhG03AczxN4Bk/pz9L9G6dWska5v/nDv/+EGX8CbSTvLfeYueYl58IzAl2I5i3oJXlZdpqf5yf6maPdx3vJwfLLQ5jVFOZHav73QnrJvuX5tTLHvNT83EwsuaDst982109eZ+/T/fx5Io+sB8iF5BVl3bKOWZe8pDxZ5pjXmt84M88F6H1vZirsS+xrBIvw51v6Ay79Cdeese6YQp4lrwyPp2uOOKG4OmRjyyXmff9Gy+zrxAulKoFtm0ewdmu89Vw+65rRNrfJs+Q95d4yx5zSXHDmntszXqG9+nL59XqhXqmX+rV+sV/tl/t1PYAA/nkAo3N4B5ePYs5aP10vPc8nbA46I/ptn03Oved+dVzu1+eAOWIO0WPmID1KDtMP1L3kPGXdMsesS14jnscyZ5xzXEDmkkHH6YF6JAvVY3EwjIbhYGuKvZ3P2NWDrj1n3TMGrc/kPeh5LnPRQdLFvpuqeYvyBJ5hpfAcP4ln8WEMp/Herw6YC9Zn8hqwNpM54azh+qbZY+wn+pnbVD/XT85k94y54zRkXXL+dJ23PGPmmvOcn56XoIP5foFgBb9EuMb8ong+QusPqveaOWf+e1Cz5JzlGTPXHOdcHLJjPehXyZfx6+QL5SvNnMt74r6T/ho/o7mBy99F6ZL3kGfJPuW85WI4h/ssXStbLFwtXU4/UPMT9cT47Z/8Jp+vnh8Y6aCh5NQjL/Hb8D2HQRei86TzBfMV8yXzNdk4LuZx7Djtj2WdMZccpKxYnv6q/Xy8SWkuTttXHXhX9arsWd3+XrjcGdlxDXkvmVPmlrnkFGD1fL0fyDHD6h8qOG7pw8qXpe9qt4ZnxLXiJGPumEOGkqOUe8t7zHHNKuf79r2vfl3+tr6quGacdMwh5yXX5+sgavWM3R+y51N2GrWu+v3vNlZfrb5cfr1eqFfqpXqtX+xX22V9vR/Bs96ar/iIS2kz3y7HW/9rq73krGCNcGguRw3riIXmVCLmEDFmDtKj5DA5Tg7U2fIH1tFx3JvOo9Ylnwxl1fQ8mKVLZty1DrufKu1av9ivjsvj+hwwR8whcowOWf/YxzyPte6a+Yb9fprUJYcF6/fLmcEcFqy3kx7Lg2k0DcfxPIFn8JT+VD0zrl4ey2+P5YHlY+YzOQ1a/h7nsaxeOYOu/ebykrwsO83P8xP9THac1h2rbbUfyZwxl5z224/k/EzO4d3p9XMzyX62n57NXxbQ7Mp42WTWx5auepZ8T7m3nMec17zvq1CJfY1YkX2VXJn6WB1/vrUfx7rc+S65l/zPgWZwkQp6ToLONl6yULBSslSyFj9NiyNZn8m64TjiT5NY8hloIFq6YdZ3Ii07TjtfLV4uXi9cUPIL24adq1GHW2frP3i6Rs+vkxM5B/ew945K5mueFb2oGj5R83EcnccfKJHkK8qz5TRmdOk9oH/YqZd17wofVdZnMesITjhu+MnRPV2foGbnj/mMzTcoj/Za7aXcU73HgnXFvEt0yHnJJcJC8ut/p4j12ZwdzrLdG+T37Xxf//z/oH8Are9g+mStc857nj9z3Uu+Q6wrTjLGF2PQNn3/jcvj+hwwR8whaswcpEfJYWQ3+FZrhz4fdFK0Lvl+JnPPQdCoJViw3JV6oB6JQvVYHKxH83Aq2kJNn1PDG0XueC/5mrJuOY3Z2V/aQrhFeQLPsFJ4jp2Ef8jhUzRXzBn7jrnk+/M1Zpx1bELmTcYzeArPsZN4lpm2zPM2mDPmjnXIuuNZ8jlmqjnL2dxuv712mX6qn7tP9rP36S7o4PPqpdsXg1zyPWQuOU3Z3ul1i+0L7CukSkRq7Iv4bvkw5tOYs07O5GvHHHJcsr/5oe4LlonVyRUKVpJfF/tbmp3Fe7WvAnvJ9VS+98xBh0Xv9z/cstFa2WLhatFyuy30EecVd/B++ZLvKXuW85iXrRDvzHzBfMWrkunn0drLYh1zWLPO2Zd875hDzkuOUc53db7obdWTsuud0TFzzXnOjWcu+f547WM+1bxvmrN2Pi18WPmsdGCvON28XX625pLvKe8sF/vwn2D5IqwHJvomUyNTJFQlVSZVB2yozjjvmEPeS76mrFvWMf/eT7Sn739RMddeyUrJUtFa2WLZasabpt8d+PX7f1/fL5X+/m42/Gt8SeSu5HvLHDMfzUAzC063Wr5evmC+4kVJuI/50bxn+yavdjpLvjfcf+8fDyKdK+HFnfRV8x0VPap6Vfaqbh5rTuu3q+8yw8xcSr4fylB0ceSJ7xW9sN914WXly9KXtfHu5PsjqvmTc8VNl/zHLeuYC8357eKgq1vu8svl1+uFeqVe6tf6xX61X+7X5QBjH/LdEOb79Nsb+7WXfG+YILaO2VfnbKEDpRApRgsSo9QwOU4P1CMdvs6jrXo0eN0W9v5tcCv5/laZUzZ/ulea7X7jSXaWn8bz7MRt5skMdpstjbkWWkv+05bL79+9Qn4HX2zypuu2uX7yNnufvs83pu5RC6TFwt+boJLvKfPBbKueXkHv28yvEC3h14gX8avky1ySTpr+dMcl/8vMHezIDcMwGH7/p85cB0EcyTF/UsfFCuQ21rcukHbyl3L1QI4uZuwQZVsmDRImKaN0Wdx56lmeJF7zJX+k/N0yiFnLWWtaDFutW08cdk5If2HWlDzTcv2cDm9n9JyBtYQi9ZlMKHtcZ5vEsK7/aj1fcp/y4QnA6wHtNBiL5ULB9AEiRu9vkStbXcmDKeuf4fq9Ib4TfIGlga4wdZxeAdB6Pjm7tJL9lCnLnkUxtXhqXLpsjGWWGcz/1JSS+c/a9Gte3M0+HFbu7j+WtczeBgp+ALYW2Zec/xfYPOi1aP+C+Pv8hf7G86uXlFtaulDJfsqo5XfM/tULdWZKI62gTXU0IZn/4IGYZcHv7dROBntTxe+/ehVnSUrf0dOXuS/Zr5hnLDn74GIHq5OeRWhZtrcXTvcv3znpJedfR9GWRTtR3Bblt8vv1wP1RD1Sz/SH2lPNMdVJ8X5P0/smv0oOX8wgZ9mWtNeyP9if3Bvtz24P96f3x4WkadT3e7jL51zy8GsZfejC9ZBGSbO0YeI0cRy+MFDBWp9Yco4yfzTyZdIH6hOZSH0mFWpYqy01eslDr2X8qTf/lzS3WVgslosF286bL1m76TOWS85jNjz4k8/gBlcbjUazmXAreV69XnL+Xs5b9hX5moxV9i5/mbat708qGaI80rK/zt/nL/Q3Bip3oEglz+ccP5pcqb81WuvvzRXv6xNLhiDPlxxu9lfnu/PlYLtE8mzO8z3n69P9+R8g/xN8d/Cv6dfeHeQgDMNAAPwf/38Qd9S4G5HWEyk9xntYKZ4LAnok918k0qG/BHQd/TXujT8i2ffsg2ZUO7Qh3xLyAeEj2aPMlcHaaHVe7/O+ZF+0T5osRDSib+3iJxD/r/g9oyPZXwqzFNfKvcEFG+5L7v/nrw1tf+xiZDP7Nudf0+ZL7jXsI6Yh25h50L+o95WsQPYl+5p90b5qX3IOu5929TnG8Ajf3206+iUXb+gbrI7kS7fFob+Fm9TcBfUC16rk9Y9Fe8B4cDyMjwfjST0qZ/Wwntbjel4H8sR9JM807tPzWI7k8Im3JUylsTiXB/NkHs2z8+E8PR9/VPiRnFPXrIN9vEJgo/6vchzJ2lagm4qWMlvN1/IlfwEhWt84q1YI3gAAAABJRU5ErkJggg==') no-repeat center top;
+}
+
+/* Tree */
+#content div.tree ul {
+	list-style: none;
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAABCAMAAADpTH4XAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRF////AAAAVcLTfgAAAA9JREFUeNpiYMAEjAABBgAAFgACaSH3bAAAAABJRU5ErkJggg==') left repeat-y;
+	padding: 0;
+	margin-left: 20px;
+}
+
+#content div.tree li {
+	margin: 0;
+	padding: 0;
+}
+
+#content div.tree div {
+	padding-left: 30px;
+}
+
+#content div.tree div.notlast {
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAABCAMAAAD+bu7eAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRFAAAA////pdmf3QAAABBJREFUeNpiYMQEDAgAEGAAAa4AFD4gfOwAAAAASUVORK5CYII=') left 10px no-repeat;
+}
+
+#content div.tree div.last {
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAH0CAMAAAAdRm3AAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRF////AAAAVcLTfgAAADxJREFUeNrsybENAAAIA6D6/9OODiY+IKwkW+WktdZaa6211lprrbXWWmuttdb6V48AAAAAAAAA8EkLMADfQwEG+L3cCAAAAABJRU5ErkJggg==') left -240px no-repeat;
+}
+
+#content div.tree li.last {
+	background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAABCAMAAADpTH4XAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRF////AAAAVcLTfgAAAA5JREFUeNpiYMACAAIMAAAVAAGK4hglAAAAAElFTkSuQmCC') left center repeat-y;
+}
+
+#content div.tree span.padding {
+	padding-left: 15px;
+}
+
+/* Source code */
+#content .php-keyword1 {
+	color: #e71818;
+	font-weight: bold;
+}
+
+#content .php-keyword2 {
+	font-weight: bold;
+}
+
+#content .php-var {
+	color: #d59401;
+	font-weight: bold;
+}
+
+#content .php-num {
+	color: #cd0673;
+}
+
+#content .php-quote {
+	color: #008000;
+}
+
+#content .php-comment {
+	color: #929292;
+}
+
+#content .xlang {
+	color: #ff0000;
+	font-weight: bold;
+}
+
+#content span.l {
+	display: block;
+}
+
+#content span.l.selected {
+	background: #f6f6f4;
+}
+
+#content span.l a {
+	color: #333333;
+}
+
+#content span.l a:hover, #content div.l a:active, #content div.l a:focus {
+	background: transparent;
+	color: #333333 !important;
+}
+
+#content span.l .php-var a {
+	color: #d59401;
+}
+
+#content span.l .php-var a:hover, #content span.l .php-var a:active, #content span.l .php-var a:focus {
+	color: #d59401 !important;
+}
+
+#content span.l a.l {
+	padding-left: 2px;
+	color: #c0c0c0;
+}
+
+#content span.l a.l:hover, #content span.l a.l:active, #content span.l a.l:focus {
+	background: transparent;
+	color: #c0c0c0 !important;
+}
+
+#content #rightInner.medium #navigation {
+	height: 52px;
+}
+
+#content #rightInner.medium #navigation ul:first-child + ul {
+	clear: left;
+	border: none;
+	padding: 0;
+}
+
+#content #rightInner.medium .name, #content #rightInner.medium .attributes {
+	white-space: normal;
+}
+
+#content #rightInner.small #search {
+	float: left;
+}
+
+#content #rightInner.small #navigation {
+	height: 78px;
+}
+
+#content #rightInner.small #navigation ul:first-child {
+	clear: both;
+}


### PR DESCRIPTION
apigen.css was taken from ApiGen's default style.css with 3 changes:
1. All images are inlined as data URIs
2. All styles are restricted to #content
3. The search bar, which doesn't work with Redmine embedded, is hidden

ApiGen is a tool similar to Doxygen but specifically designed for PHP. My company needs ApiGen support in order to integrate our ApiGen documentation into Redmine.
