### PR TITLE
Display ApiGen hidden content

### DIFF
--- a/assets/stylesheets/apigen.css
+++ b/assets/stylesheets/apigen.css
@@ -112,10 +112,6 @@
 	color: #e71818;
 }
 
-#content .hidden {
-	display: none;
-}
-
 /* Left side */
 #content #left {
 	overflow: hidden;


### PR DESCRIPTION
Descriptions of function arguments are normally hidden until a mouse
click triggers JavaScript that unhides them, but we don't have
JavaScript here.
